### PR TITLE
Add `skipMountTransition` prop

### DIFF
--- a/src/components/Animator/components/AnimatorParent.js
+++ b/src/components/Animator/components/AnimatorParent.js
@@ -15,13 +15,13 @@ class AnimatorParent extends React.Component {
   }
 
   render() {
-    const {className, dataHook} = this.props;
+    const {className, dataHook, skipMountTransition} = this.props;
     const animatorProps = formatProps(this.props);
     animatorProps.debug = this.state.debug;
     return (
       <TransitionGroup data-hook={dataHook} className={className}>
         {animatorProps.children.map((item, index) =>
-          <CSSTransitionWrapper key={item.key || index} index={index} {...item.props} animatorProps={animatorProps}>
+          <CSSTransitionWrapper skipMountTransition={skipMountTransition} key={item.key || index} index={index} {...item.props} animatorProps={animatorProps}>
             {item}
           </CSSTransitionWrapper>
         )}
@@ -38,7 +38,12 @@ AnimatorParent.propTypes = {
   className: any,
   show: any,
   dataHook: any,
-  debug: bool
+  debug: bool,
+  skipMountTransition: bool,
+};
+
+AnimatorParent.defaultProps = {
+  skipMountTransition: false,
 };
 
 export default AnimatorParent;

--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -13,10 +13,8 @@ class CSSTransitionWrapper extends React.Component {
   constructor(props) {
     super(props);
 
-    const isEntered = Boolean(props.skipMountTransition && props.animatorProps.show);
-
     this.transitionDefault = {
-      enter: isEntered,
+      enter: false,
       entering: false,
       exit: false,
       exiting: false
@@ -25,16 +23,7 @@ class CSSTransitionWrapper extends React.Component {
     this.state = {
       sequenceIndex: 0,
       transition: this.transitionDefault,
-      skipEnterTransition: isEntered,
     };
-  }
-
-  componentDidMount() {
-    const {skipEnterTransition} = this.state;
-    // Don't skip transitions after mounting
-    if (skipEnterTransition) {
-      this.setState({skipEnterTransition: false});
-    }
   }
 
   componentWillReceiveProps(props) {
@@ -106,7 +95,6 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   getTransitionProps() {
-    const {skipEnterTransition} = this.state;
     const duration = new Time(this.props.animatorProps, this.state.transition).getTotalDuration();
 
     const showByProp = {};
@@ -115,9 +103,9 @@ class CSSTransitionWrapper extends React.Component {
     }
 
     return {
-      enter: !skipEnterTransition && !!duration,
+      enter: !!duration,
       exit: !!duration,
-      appear: !!duration,
+      appear: !this.props.skipMountTransition && !!duration,
       timeout: duration,
       classNames: transitionClassNames,
       mountOnEnter: true,

--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -95,17 +95,19 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   getTransitionProps() {
-    const duration = new Time(this.props.animatorProps, this.state.transition).getTotalDuration();
+    const {animatorProps, skipMountTransition} = this.props;
+    const {transition} = this.state;
+    const duration = new Time(animatorProps, transition).getTotalDuration();
 
     const showByProp = {};
-    if (this.props.animatorProps.show !== undefined) {
-      showByProp.in = this.props.animatorProps.show;
+    if (animatorProps.show !== undefined) {
+      showByProp.in = animatorProps.show;
     }
 
     return {
       enter: !!duration,
       exit: !!duration,
-      appear: !this.props.skipMountTransition && !!duration,
+      appear: !skipMountTransition && !!duration,
       timeout: duration,
       classNames: transitionClassNames,
       mountOnEnter: true,

--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {node, number, object} from 'prop-types';
+import {node, number, object, bool} from 'prop-types';
 import CSSTransition from 'react-transition-group/CSSTransition';
 import {transitionClassNames} from '../constants/constants';
 import {Time} from '../class/time-class';
@@ -13,8 +13,10 @@ class CSSTransitionWrapper extends React.Component {
   constructor(props) {
     super(props);
 
+    const isEntered = Boolean(props.skipMountTransition && props.animatorProps.show);
+
     this.transitionDefault = {
-      enter: false,
+      enter: isEntered,
       entering: false,
       exit: false,
       exiting: false
@@ -22,8 +24,17 @@ class CSSTransitionWrapper extends React.Component {
 
     this.state = {
       sequenceIndex: 0,
-      transition: this.transitionDefault
+      transition: this.transitionDefault,
+      skipEnterTransition: isEntered,
     };
+  }
+
+  componentDidMount() {
+    const { skipEnterTransition } = this.state;
+    // Don't skip transitions after mounting
+    if (skipEnterTransition) {
+      this.setState({ skipEnterTransition: false });
+    }
   }
 
   componentWillReceiveProps(props) {
@@ -95,7 +106,7 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   getTransitionProps() {
-
+    const { skipEnterTransition } = this.state;
     const duration = new Time(this.props.animatorProps, this.state.transition).getTotalDuration();
 
     const showByProp = {};
@@ -104,7 +115,7 @@ class CSSTransitionWrapper extends React.Component {
     }
 
     return {
-      enter: !!duration,
+      enter: !skipEnterTransition && !!duration,
       exit: !!duration,
       appear: !!duration,
       timeout: duration,
@@ -154,7 +165,8 @@ class CSSTransitionWrapper extends React.Component {
 CSSTransitionWrapper.propTypes = {
   index: number,
   children: node,
-  animatorProps: object
+  animatorProps: object,
+  skipMountTransition: bool
 };
 
 export default CSSTransitionWrapper;

--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -30,10 +30,10 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   componentDidMount() {
-    const { skipEnterTransition } = this.state;
+    const {skipEnterTransition} = this.state;
     // Don't skip transitions after mounting
     if (skipEnterTransition) {
-      this.setState({ skipEnterTransition: false });
+      this.setState({skipEnterTransition: false});
     }
   }
 
@@ -106,7 +106,7 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   getTransitionProps() {
-    const { skipEnterTransition } = this.state;
+    const {skipEnterTransition} = this.state;
     const duration = new Time(this.props.animatorProps, this.state.transition).getTotalDuration();
 
     const showByProp = {};

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -35,6 +35,7 @@ declare namespace WixAnimations {
     dataHook?: string;
     childClassName?: string;
     children: React.ReactNode;
+    skipMountTransition?: boolean;
   }
 
   export class Animator extends React.Component<AnimatorProps> {}

--- a/stories/Animations/FullAPI.md
+++ b/stories/Animations/FullAPI.md
@@ -14,6 +14,7 @@
 | debug | boolean | false |true, false | Provides a tool to simulate animation phases |
 | dataHook | string | - | - | will convert to data-hook |
 | childClassName | string | false | - | It will assign a className to the direct children of the Animator component. It is designed for layout purposes |
+| skipMountTransition | boolean | false | - | If set to `true`, doesn't perform transition on Animator mount |
 
 # Props of Children of Animator Component
 


### PR DESCRIPTION
Uses react-transition-group `appear` prop:
http://reactcommunity.org/react-transition-group/transition#Transition-prop-appear

If skipMountTransition is true, animation does not happen right after mounting component