### PR TITLE
Fix removing Animator children

### DIFF
--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -95,14 +95,20 @@ class CSSTransitionWrapper extends React.Component {
   }
 
   getTransitionProps() {
-    const {animatorProps, skipMountTransition} = this.props;
+    const {
+      animatorProps,
+      skipMountTransition,
+      // Injected by `TransitionGroup`, false if element is being removed from DOM
+      // eslint-disable-next-line react/prop-types
+      in: inProp
+    } = this.props;
     const {transition} = this.state;
     const duration = new Time(animatorProps, transition).getTotalDuration();
 
-    const showByProp = {};
-    if (animatorProps.show !== undefined) {
-      showByProp.in = animatorProps.show;
-    }
+    const showByProp = {
+      // Set in to false if element is exiting
+      in: inProp === false ? false : animatorProps.show,
+    };
 
     return {
       enter: !!duration,

--- a/src/components/Animator/components/CSSTransitionWrapper.js
+++ b/src/components/Animator/components/CSSTransitionWrapper.js
@@ -106,8 +106,8 @@ class CSSTransitionWrapper extends React.Component {
     const duration = new Time(animatorProps, transition).getTotalDuration();
 
     const showByProp = {
-      // Set in to false if element is exiting
-      in: inProp === false ? false : animatorProps.show,
+      // False if `show` is manually set to false, otherwise determined by TransitionGroup transition state
+      in: animatorProps.show === false ? false : inProp,
     };
 
     return {


### PR DESCRIPTION
Reported here:
https://wix.slack.com/archives/C39FTGUBZ/p1608289210271500?thread_ts=1608125996.258100&cid=C39FTGUBZ

Our implementation of react-transition-group doesn't allow removing children of Animator.
TransitionGroup passes an `in` prop to each transition and only removes from DOM Transition elements with `in={false}`.
By always passing the value of `show` to `in`, we broke that mechanism.